### PR TITLE
Recommend exclude sensor.xiaomi_map from recorder

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,14 @@ crop:
   right: 0
 ```
 
+It's highly recommended to exclude the sensor from recorder in configuration.yaml to keep database small:
+```yaml
+recorder:
+  exclude:
+    entities:
+      - sensor.xiaomi_map
+```
+
 ## Options
 | Name | Type | Default | Description
 | ---- | ---- | ------- | -----------


### PR DESCRIPTION
I was wondering why my database was getting so big. Especially why it was growing so ridiculously fast sometimes - and sometimes not.
Now I realised that it is the map data which makes the database so big. Of course ... new map data every 5 seconds for about an hour (~ 800 MB) every two days 😆

If you want you can change my text to something better :)