### PR TITLE
Add new option show_locate_button (default false)

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ min_height: 0
 | show_pause_button | boolean | true | Show the pause button for vacuum_entity
 | show_stop_button | boolean | true | Show the stop button for vacuum_entity
 | show_home_button | boolean | true | Show the home button for vacuum_entity
+| show_locate_button | boolean | true | Show the locate button for vacuum_entity
 | goto_target_icon | string | mdi:pin | The icon to use for the go to target
 | goto_target_color | string | 'blue' | The color to use for the go to target icon
 | dock_icon | string | mdi:flash | The icon to use for the charging dock

--- a/valetudo-map-card.js
+++ b/valetudo-map-card.js
@@ -528,7 +528,7 @@ class ValetudoMapCard extends HTMLElement {
     if (this._config.show_pause_button === undefined) this._config.show_pause_button = true;
     if (this._config.show_stop_button === undefined) this._config.show_stop_button = true;
     if (this._config.show_home_button === undefined) this._config.show_home_button = true;
-    if (this._config.show_locate_button === undefined) this._config.show_locate_button = false;
+    if (this._config.show_locate_button === undefined) this._config.show_locate_button = true;
 
     // Width settings
     if (this._config.virtual_wall_width === undefined) this._config.virtual_wall_width = 1;


### PR DESCRIPTION
Add new option show_locate_button, calls the service vacuum.locate in HA
Default value for this option is false, so no changes in appearance of current configurations should happen.