### PR TITLE
Add left-padding option

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ min_height: 0
 | map_scale | number | 1 | Scale the map by this value
 | icon_scale | number | 1 | Scale the icons (vacuum & dock) by this value
 | rotate | number | 0 | Value to rotate the map by (default is in deg, but a value like `2rad` is valid too)
+| left_padding | number | 0 | Value that moves the map `number` pixels from left to right 
 | crop | Object | {top: 0, bottom: 0, left: 0, right: 0} | Crop the map
 | min_height | string | 0 | The minimum height of the card the map is displayed in, regardless of the map's size itself. Suffix with 'w' if you want it to be times the width (ex: 0.5625w is equivalent to a picture card's 16x9 aspect_ratio)
 | custom_buttons | array | [] | An array of custom buttons. Options detailed below.

--- a/valetudo-map-card.js
+++ b/valetudo-map-card.js
@@ -534,6 +534,9 @@ class ValetudoMapCard extends HTMLElement {
     if (this._config.virtual_wall_width === undefined) this._config.virtual_wall_width = 1;
     if (this._config.path_width === undefined) this._config.path_width = 1;
 
+    // Padding settings
+    if (this._config.left_padding === undefined) this._config.left_padding = 0;
+    
     // Scale settings
     if (this._config.map_scale === undefined) this._config.map_scale = 1;
     if (this._config.icon_scale === undefined) this._config.icon_scale = 1;
@@ -748,6 +751,7 @@ class ValetudoMapCard extends HTMLElement {
           height: ${containerHeight}px;
           padding-top: ${containerMinHeightPadding}px;
           padding-bottom: ${containerMinHeightPadding}px;
+          padding-left: ${this._config.left_padding}px;
           overflow: hidden;
         }
         #lovelaceValetudoCard {


### PR DESCRIPTION
When you need to move map over picture elements, the only way you can do it now is to use crop parameters with negative values. Unfortunately, it's not working when you need to move map to the right side. See: #73
This commit adds left_padding card parameter, that allows you to set offset from left edge and shift map to the right side.

TO DO:
rewrite original code to make all paddings work correctly (I tried to add bottom-padding and it didn't work).