### PR TITLE
Allow for rendering of maps with compressed pixels

### DIFF
--- a/valetudo-map-card.js
+++ b/valetudo-map-card.js
@@ -693,6 +693,25 @@ class ValetudoMapCard extends HTMLElement {
     if (attributes.__class === 'ValetudoMap') {
       canDrawMap = true;
     }
+    
+    if (attributes.metaData?.version === 2 && Array.isArray(attributes.layers)) {
+      attributes.layers.forEach(layer => {
+        if(layer.pixels.length === 0 && layer.compressedPixels.length !== 0) {
+          for (let i = 0; i < layer.compressedPixels.length; i = i + 3) {
+            const xStart = layer.compressedPixels[i];
+            const y = layer.compressedPixels[i+1]
+            const count = layer.compressedPixels[i+2]
+
+            for(let j = 0; j < count; j++) {
+              layer.pixels.push(
+                  xStart + j,
+                  y
+              );
+            }
+          }
+        }
+      })
+    }
 
     if (!infoEntity || infoEntity['state'] === 'unavailable' || !infoEntity.attributes) {
       canDrawControls = false;


### PR DESCRIPTION
If https://github.com/Hypfer/Valetudo/tree/feat_pixel_compression gets merged, this would allow the card to continue operating as it does now.

It's  more or less the same code used by the Valetudo frontend